### PR TITLE
update for springboot 2.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>security</artifactId>
-    <version>2.7.0</version>
+    <version>2.7.1</version>
     <packaging>jar</packaging>
 
     <name>wily-security</name>
@@ -33,13 +33,13 @@
     </scm>
 
     <properties>
-        <wily-exceptions.version>2.7.0</wily-exceptions.version>
+        <wily-exceptions.version>2.7.1</wily-exceptions.version>
     </properties>
 
     <parent>
         <groupId>io.csra.wily</groupId>
         <artifactId>dependencies</artifactId>
-        <version>2.7.0</version>
+        <version>2.7.1</version>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
update for wily-security to 2.7.1
wily-exceptions must be deployed first